### PR TITLE
Don't NODE_PATH if it already defined + fix appveyor.xml for windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in metanorma.gemspec
 gemspec
+
+gem 'metanorma-standoc', :git => 'https://github.com/riboseinc/metanorma-standoc.git', :branch => 'fix-dont-open-binary-files-as-utf8-encoded'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/riboseinc/metanorma-standoc.git
+  revision: dd8814923dc994c820b87920cb3768822b2b9c43
+  branch: fix-dont-open-binary-files-as-utf8-encoded
+  specs:
+    metanorma-standoc (1.0.14)
+      asciidoctor (~> 1.5.7)
+      concurrent-ruby
+      iev (~> 0.2.0)
+      isodoc (~> 0.9.0)
+      relaton (~> 0.3.1)
+      ruby-jing
+      sterile (~> 1.0.14)
+
 PATH
   remote: .
   specs:
@@ -75,14 +89,6 @@ GEM
       isodoc (~> 0.9.8)
       metanorma-standoc (~> 1.0.0)
       ruby-jing
-    metanorma-standoc (1.0.14)
-      asciidoctor (~> 1.5.7)
-      concurrent-ruby
-      iev (~> 0.2.0)
-      isodoc (~> 0.9.0)
-      relaton (~> 0.3.1)
-      ruby-jing
-      sterile (~> 1.0.14)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
@@ -151,6 +157,7 @@ DEPENDENCIES
   isodoc (= 0.9.13)
   metanorma!
   metanorma-iso (~> 1.0.12)
+  metanorma-standoc!
   rake (~> 12.0)
   rspec (~> 3.0)
   rspec-command (~> 1.0.3)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,34 @@ matrix:
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  - gem install bundler -v 1.16.1
+  - gem install bundler -v 2.0.1
   - npm install -g puppeteer
   - npm install
-  - bundle install
+  # install libxml2 & libxslt
+  - ps: Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+  - refreshenv
+  - cinst --x86 xsltproc
+  - set XSLT_PROC=%ChocolateyInstall%\lib\xsltproc\dist
+  # RUBY_DLL_PATH looks broken in ruby23
+  - if "%RUBY_VERSION%" == "23" (
+      XCOPY /Y %XSLT_PROC%\bin\lib*.dll C:\Ruby%RUBY_VERSION%\bin\*
+    ) else (
+      XCOPY /Y %XSLT_PROC%\bin\libxml2*.dll %XSLT_PROC%\bin\libxml2.dll* &
+      XCOPY /Y %XSLT_PROC%\bin\libxslt*.dll %XSLT_PROC%\bin\libxslt.dll* &
+      XCOPY /Y %XSLT_PROC%\bin\libexslt*.dll %XSLT_PROC%\bin\libexslt.dll*
+    )
+  - echo @ECHO OFF > %ChocolateyInstall%\bin\xml2-config.bat
+  - echo @ECHO OFF > %ChocolateyInstall%\bin\xslt-config.bat
 
-build: off
+build_script:
+  # RUBY_DLL_PATH looks broken in ruby23
+  - if NOT "%RUBY_VERSION%" == "23" setx /M RUBY_DLL_PATH "%ChocolateyInstall%\lib\xsltproc\dist\bin;%RUBY_DLL_PATH%"
+  - refreshenv
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - set XSLT_PROC=%ChocolateyInstall%\lib\xsltproc\dist
+  - bundle config build.ruby-xslt --with-xml2-include=%XSLT_PROC%\include\libxml2 --with-xslt-include=%XSLT_PROC%\include --with-xml2-lib=%XSLT_PROC%\lib --with-xslt-lib=%XSLT_PROC%\lib
+  - bundle update
+  - bundle install
 
 before_test:
   - ruby -v

--- a/lib/metanorma/output/pdf.rb
+++ b/lib/metanorma/output/pdf.rb
@@ -5,7 +5,7 @@ module Metanorma
       def convert(url_path, output_path)
         file_url = "file://#{Dir.pwd}/#{url_path}"
         pdfjs = File.join(File.dirname(__FILE__), '../../../bin/metanorma-pdf.js')
-        ENV['NODE_PATH'] = `npm root --quiet -g`.strip
+        ENV['NODE_PATH'] ||= `npm root --quiet -g`.strip
         system "node #{pdfjs} #{file_url} #{output_path}"
         #Phantomjs.path
         #pdfjs = File.join(File.dirname(__FILE__), "../../../bin/rasterize.js")


### PR DESCRIPTION
 - based on #35

tests crashes for base64 encoded images like this `data:image/png;base64;......`